### PR TITLE
some updates after an evening of use

### DIFF
--- a/m5paperwardriver/m5paperwardriver.ino
+++ b/m5paperwardriver/m5paperwardriver.ino
@@ -266,10 +266,14 @@ int magicIndex(const char* mac) {
 /* Where did all this come from?
  *
  * ESP32 type codes
+ * apparently only these ones are supported
+ * https://github.com/espressif/arduino-esp32/blob/master/libraries/WiFi/src/STA.cpp#L88
+ * despite having a bigger list here
  * https://github.com/espressif/arduino-esp32/blob/master/libraries/WiFi/src/STA.cpp#L703
+ * and this is a different esp lib entirely which we aren't using?  Can we?
  * https://github.com/espressif/esp-idf/blob/master/components/esp_wifi/include/esp_wifi_types_generic.h#L66
  *
- * Android Type codes
+ * Android Type codes, what wigle csv wants
  * https://developer.android.com/reference/android/net/wifi/WifiConfiguration.KeyMgmt ?
  * https://android.googlesource.com/platform/prebuilts/fullsdk/sources/android-30/+/refs/heads/main/com/android/server/wifi/util/InformationElementUtil.java#1016 ??
  */
@@ -285,8 +289,8 @@ const char* getAuthType(uint8_t wifiAuth) {
       return "[WPA2_PSK]";
     case WIFI_AUTH_WPA_WPA2_PSK:
       return "[WPA_WPA2_PSK]";
-    case WIFI_AUTH_ENTERPRISE:
-      return "[WPA_ENTERPRISE]";
+    // case WIFI_AUTH_ENTERPRISE:
+    //  return "[WPA_ENTERPRISE]";
     case WIFI_AUTH_WPA2_ENTERPRISE:
       return "[WPA2_ENTERPRISE]";
     case WIFI_AUTH_WPA3_PSK:
@@ -295,18 +299,18 @@ const char* getAuthType(uint8_t wifiAuth) {
       return "[WPA2_WPA3_PSK]";
     case WIFI_AUTH_WAPI_PSK:
       return "[WAPI_PSK]";
-    case WIFI_AUTH_OWE:
-      return "[OWE]";
-    case WIFI_AUTH_WPA3_ENT_192:
-      return "[RSN-EAP_SUITE_B_192-GCMP-256]";
-    case WIFI_AUTH_WPA3_EXT_PSK:
-      return "[WPA3_PSK_DEPRECATED_EXT]";
-    case WIFI_AUTH_WPA3_EXT_PSK_MIXED_MODE:
-      return "[WPA3_PSK_DEPRECATED_EXT]";
-    case WIFI_AUTH_DPP:
+    // case WIFI_AUTH_OWE:
+    //  return "[OWE]";
+    // case WIFI_AUTH_WPA3_ENT_192:
+    //  return "[RSN-EAP_SUITE_B_192-GCMP-256]";
+    // case WIFI_AUTH_WPA3_EXT_PSK:
+    //  return "[WPA3_PSK_DEPRECATED_EXT]";
+    // case WIFI_AUTH_WPA3_EXT_PSK_MIXED_MODE:
+    //  return "[WPA3_PSK_DEPRECATED_EXT]";
+    // case WIFI_AUTH_DPP:
       // DPP is an AUTH mechanism that works with both WPA2 and WPA3
       // esp32 gives no indication of which, so I'm just calling it WPA2 since that's the lowest option
-      return "[WPA2_DPP]";
+    //  return "[WPA2_DPP]";
     default:
       return "[UNKNOWN]";
   }
@@ -401,9 +405,15 @@ void loop() {
   if (!gps.location.isValid()) {
     Serial.println("Waiting for valid GPS data...");
   }
+
+  // Set the minimum time per channel for active scanning.
+  // This doesn't work despite being in the example code?
+  // https://github.com/espressif/arduino-esp32/blob/master/libraries/WiFi/examples/WiFiScanTime/WiFiScanTime.ino#L22
+  // WiFi.setScanActiveMinTime(103); // default minimum is 100ms
   // TODO Convert to async
   // https://github.com/espressif/arduino-esp32/blob/master/libraries/WiFi/examples/WiFiScanAsync/WiFiScanAsync.ino
   // Scan + hidden networks, at Nyquist sampling rate of 200ms per channel
+  // async false, show_hidden true, passive false, max_ms_per_chan 200
   int n = WiFi.scanNetworks(false,true,false,200);
   if (n > 0) {
     GPSData gpsData = getGPSData();

--- a/m5paperwardriver/m5paperwardriver.ino
+++ b/m5paperwardriver/m5paperwardriver.ino
@@ -59,11 +59,10 @@ struct Device {
   String ssid;
   String mac;
   int rssi;
-  String info;
   int64_t ts = esp_timer_get_time() - display_timeout - 1; //timestamp since boot in microseconds, initialized to be outside the display timeout
 };
 
-const int max_devices = 825;
+const int max_devices = 1025;
 int64_t init_timeout = esp_timer_get_time() - display_timeout;
 Device deviceList[max_devices];
 std::mutex deviceListMutex;
@@ -209,12 +208,18 @@ void displayDevices() {
         drawHeader(mNumWifi, mNumBLE);
         y = 45;
       }
-      canvas.drawString(String(dCount) + ": " + deviceList[i].info, 10, y);
+
+      canvas.drawString(String(dCount) + ": " +
+        deviceList[i].type + ": " +
+        deviceList[i].ssid +
+        " (" + deviceList[i].mac + ") " +
+        deviceList[i].rssi
+        , 10, y);
     }
   }
   deviceListMutex.unlock();
   mutexDebug("Mutex released by main device display loop");
-  canvas.pushCanvas(0, 0, UPDATE_MODE_GLR16);
+  canvas.pushCanvas(0, 0, UPDATE_MODE_DU);
 }
 
 GPSData getGPSData() {
@@ -297,7 +302,6 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks {
       deviceList[deviceIndex].ssid = ssid;
       deviceList[deviceIndex].mac = mac;
       deviceList[deviceIndex].rssi = rssi;
-      deviceList[deviceIndex].info = "BLE: " + String(ssid) + " (" + String(mac) + ") RSSI: " + String(rssi);
       deviceList[deviceIndex].ts = esp_timer_get_time();
     }
     mutexDebug("Mutex released by BT Callback");
@@ -391,7 +395,6 @@ void loop() {
         deviceList[deviceIndex].ssid = ssid;
         deviceList[deviceIndex].mac = bssid;
         deviceList[deviceIndex].rssi = rssi;
-        deviceList[deviceIndex].info = "WiFi: " + ssidStr + " (" + bssidStr + ") RSSI: " + String(rssi);
         deviceList[deviceIndex].ts = esp_timer_get_time();
       }
       mutexDebug("Mutex released by wifi loop");

--- a/m5paperwardriver/m5paperwardriver.ino
+++ b/m5paperwardriver/m5paperwardriver.ino
@@ -98,7 +98,7 @@ void displayDevices() {
   for (int i = 0; i < deviceIndex; i++) {
     y += 30;
     if (y > canvas.height() - 20) {
-      canvas.pushCanvas(0, 0, UPDATE_MODE_DU4);
+      canvas.pushCanvas(0, 0, UPDATE_MODE_DU);
       delay(2000);
       canvas.fillCanvas(0);
       canvas.drawString("GPS: " + gpsValid + " | HDOP: " + String(gps.hdop.value()) + " | WiFi:" + String(mNumWifi) + " | BLE:" + String(mNumBLE), 10, 10);

--- a/m5paperwardriver/m5paperwardriver.ino
+++ b/m5paperwardriver/m5paperwardriver.ino
@@ -225,6 +225,7 @@ void loop() {
       displayDevices();
     }
   }
+  WiFi.scanDelete();
 
   pBLEScan->start(scanTime, false);
   pBLEScan->clearResults();

--- a/m5paperwardriver/m5paperwardriver.ino
+++ b/m5paperwardriver/m5paperwardriver.ino
@@ -93,7 +93,7 @@ void drawHeader(int mNumWifi, int mNumBLE) {
   canvas.fillCanvas(0);
   String gpsValid = gps.location.isValid() ? "Valid" : "Invalid";  // gps status for top text
   // Normal Info header
-  // canvas.drawString("GPS: " + gpsValid + " | HDOP: " + String(gps.hdop.value()) + " | WiFi:" + String(mNumWifi) + " | BLE:" + String(mNumBLE), 10, 10);
+  canvas.drawString("GPS: " + gpsValid + " | HDOP: " + String(gps.hdop.value()) + " | WiFi:" + String(mNumWifi) + " | BLE:" + String(mNumBLE), 10, 10);
 
   // Memory debugging Info header
   // canvas.drawString("Free " + String(esp_get_minimum_free_heap_size()) + " | WiFi:" + String(mNumWifi) + " | BLE:" + String(mNumBLE), 10, 10);
@@ -110,7 +110,7 @@ void drawHeader(int mNumWifi, int mNumBLE) {
     battVolt = BATT_MAX;
   }
   // Calculate percentage
-  float batteryPercent = ((float)(battVolt - BATT_MIN) / (float)BATT_DIFF ) * 100;
+  float batteryPercent = ((float)(battVolt - BATT_MIN) / (float)BATT_DIFF );
   // slowing pulling line in from both sides toward the middle as it drains
   int halfLineSize = (float)270 * batteryPercent;
   // Left half of line

--- a/m5paperwardriver/m5paperwardriver.ino
+++ b/m5paperwardriver/m5paperwardriver.ino
@@ -94,19 +94,21 @@ void displayDevices() {
   canvas.drawString("GPS: " + gpsValid + " | HDOP: " + String(gps.hdop.value()) + " | WiFi:" + String(mNumWifi) + " | BLE:" + String(mNumBLE), 10, 10);
   canvas.drawLine(10, 30, 540, 30, 15);
 
-  int y = 40;
+  int y = 15;
   for (int i = 0; i < deviceIndex; i++) {
-    canvas.drawString(String(i + 1) + ": " + deviceList[i].info, 10, y);
     y += 30;
     if (y > canvas.height() - 20) {
       canvas.pushCanvas(0, 0, UPDATE_MODE_DU4);
       delay(2000);
       canvas.fillCanvas(0);
-      y = 40;
+      canvas.drawString("GPS: " + gpsValid + " | HDOP: " + String(gps.hdop.value()) + " | WiFi:" + String(mNumWifi) + " | BLE:" + String(mNumBLE), 10, 10);
+      canvas.drawLine(10, 30, 540, 30, 15);
+      y = 45;
     }
+    canvas.drawString(String(i + 1) + ": " + deviceList[i].info, 10, y);
   }
 
-  canvas.pushCanvas(0, 0, UPDATE_MODE_GC16);
+  canvas.pushCanvas(0, 0, UPDATE_MODE_GLR16);
 }
 
 GPSData getGPSData() {
@@ -143,8 +145,6 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks {
     deviceList[deviceIndex].info = "BLE: " + String(ssid) + " (" + String(mac) + ") RSSI: " + String(rssi) + " dBm";
     deviceIndex++;
     mNumBLE ++;
-
-    displayDevices();
   }
 };
 
@@ -167,16 +167,24 @@ void setup() {
   canvas.createCanvas(540, 960);  // Correct full vertical canvas size
   canvas.setTextSize(2);
 
+  delay(2000);
   if (!initSDCard()) {
     Serial.println("Failed to initialize SD card. Halting...");
+    canvas.drawString("Failed to initialize SD card. Halting...", 10, 40);
+    canvas.pushCanvas(0, 0, UPDATE_MODE_GLR16);
     while (true) delay(1000);
   }
+  canvas.drawString("SD card initialized...", 10, 40);
+  canvas.pushCanvas(0, 0, UPDATE_MODE_GLR16);
+  delay(1000);
 
   GPS_Serial.begin(9600, SERIAL_8N1, 19, 18);
-  canvas.drawString("GPS initialized.", 10, 40);
-  canvas.pushCanvas(0, 0, UPDATE_MODE_GC16);
-  delay(2000);
+  canvas.drawString("GPS initialized...", 10, 70);
+  canvas.pushCanvas(0, 0, UPDATE_MODE_GLR16);
+  delay(1000);
 
+  canvas.drawString("Scanning initialized...", 10, 100);
+  canvas.pushCanvas(0, 0, UPDATE_MODE_GLR16);
   initializeScanning();
 }
 
@@ -221,14 +229,14 @@ void loop() {
       deviceList[deviceIndex].info = "WiFi: " + ssidStr + " (" + bssidStr + ") RSSI: " + String(rssi) + " dBm";
       deviceIndex++;
       mNumWifi ++;
-
-      displayDevices();
     }
   }
   WiFi.scanDelete();
 
   pBLEScan->start(scanTime, false);
   pBLEScan->clearResults();
+
+  displayDevices();
 
   delay(2000);
 }

--- a/m5paperwardriver/m5paperwardriver.ino
+++ b/m5paperwardriver/m5paperwardriver.ino
@@ -42,7 +42,7 @@ struct Device {
   String info;
 };
 
-Device deviceList[750];
+Device deviceList[500];
 int deviceIndex = 0;
 
 void writeCSVHeader() {
@@ -186,7 +186,13 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks {
       deviceList[deviceIndex].rssi = rssi;
       deviceList[deviceIndex].info = "BLE: " + String(ssid) + " (" + String(mac) + ") RSSI: " + String(rssi) + " dBm";
       deviceIndex++;
-      mNumBLE ++;
+      if (deviceIndex > (sizeof(deviceList)/sizeof(deviceList[0]))) {
+        deviceIndex = 0;
+        mNumWifi = 0;
+        mNumBLE = 0;
+      } else {
+        mNumBLE ++;
+      }
     }
   }
 };
@@ -274,7 +280,13 @@ void loop() {
         deviceList[deviceIndex].rssi = rssi;
         deviceList[deviceIndex].info = "WiFi: " + ssidStr + " (" + bssidStr + ") RSSI: " + String(rssi) + " dBm";
         deviceIndex++;
-        mNumWifi ++;
+        if (deviceIndex > (sizeof(deviceList)/sizeof(deviceList[0]))) {
+          deviceIndex = 0;
+          mNumWifi = 0;
+          mNumBLE = 0;
+        } else {
+          mNumWifi ++;
+        }
       }
     }
   }
@@ -283,5 +295,5 @@ void loop() {
   pBLEScan->start(scanTime, false);
   pBLEScan->clearResults();
 
-  displayDevices();
+  displayDevices(); // the wifi scan takes time so no need to delay here
 }


### PR DESCRIPTION
clean the wifi scan result data to free ram
I have been noticing that the existing code has been crashing
frequently.  The example code frees ram, might not fix the crash, but
probably won't hurt.  jhewitt doesn't do it, so maybe it's like the
close door button on the elevator.

Added some startup output for errors and successes

Reduced calls to displayDevices for predictability.  Now displayDevices
is called once per wifi scan instead of once per found device.  This
drastically reduces flashing on the screen.

Rewrote displayDevices to not turn the page when there is nothing to
write.

Rewrote displayDevices to show the header on every page.

Switched UPDATE_MODE_ per the docs to reduce flashing and improve speed
while not affecting text quality.