### PR TITLE
Remove lowest rssi from device list to prevent overflow #6

### DIFF
--- a/m5paperwardriver/m5paperwardriver.ino
+++ b/m5paperwardriver/m5paperwardriver.ino
@@ -225,6 +225,7 @@ void loop() {
       displayDevices();
     }
   }
+  WiFi.scanDelete();  // flush scan
 
   pBLEScan->start(scanTime, false);
   pBLEScan->clearResults();


### PR DESCRIPTION
Changed:
- Clear wifi scan memory
- Use char arrays for device structure for stability 
- Remove lowest RSSI devices from the list when it hits 150. This number can be higher, please test.